### PR TITLE
:sparkles: feat: add SQL script for listing stock levels

### DIFF
--- a/estoque/lisgatem de estoque.sql
+++ b/estoque/lisgatem de estoque.sql
@@ -1,0 +1,17 @@
+select
+    e.saldoestoque_deposito_codigo_fk as codigo_deposito,
+    g.grunome as nome_grupo,
+    s.subnome as nome_subgrupo,
+    e.saldoestoque_produto_codigo_fk as codigo_produto,
+    p.pronome as nome_produto,
+    e.saldoestoque_qtde_saldo_estoque as quantidade_saldo
+
+from pw_saldo_estoque e
+    inner join produto p on p.produto = e.saldoestoque_produto_codigo_fk
+    inner join grupo g on g.grupo = p.grupo
+    inner join grupo1 s on s.subgrupo = p.subgrupo
+        and s.grupo = p.grupo
+
+where e.saldoestoque_deposito_codigo_fk = 2
+    and e.saldoestoque_qtde_saldo_estoque > 0
+limit 100;


### PR DESCRIPTION
This commit introduces a new SQL script (`estoque/lisgatem de estoque.sql`) to list stock levels for a specific warehouse (deposito).

The script retrieves the following information:

- Warehouse code
- Group name
- Subgroup name
- Product code
- Product name
- Stock quantity

It joins the `pw_saldo_estoque`, `produto`, `grupo`, and `grupo1` tables to gather the necessary data. The script filters the results to show only products with a positive stock quantity in warehouse 2 and limits the output to 100 rows.